### PR TITLE
Fix tab grid on Roblox games pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "update_url": "https://clients2.google.com/service/update2/crx",
   "manifest_version": 2,
   "name": "RoMonitor Stats - Roblox Stats",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "View Roblox game analytics from RoMonitor Stats inside Roblox",
   "content_scripts": [
     {

--- a/romonitor.css
+++ b/romonitor.css
@@ -3,3 +3,7 @@
     margin: 5px;
     height: 100px;
 }
+/* Fixes tab issues on the Roblox games page */
+.rbx-tab {
+    width: 25% !important;
+}


### PR DESCRIPTION
Fixes an issue where only three tabs would be displayed
![image](https://user-images.githubusercontent.com/11857573/88830647-286a3400-d1c6-11ea-89a2-31daf2b480c2.png)
