### PR TITLE
Change domain to romonitorstats.com

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,8 +1,8 @@
 {
   "update_url": "https://clients2.google.com/service/update2/crx",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "RoMonitor Stats - Roblox Stats",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "View Roblox game analytics from RoMonitor Stats inside Roblox",
   "content_scripts": [
     {
@@ -16,7 +16,7 @@
         "*://*.roblox.com/games/*",
         "*://*.roblox.com/users/*",
         "*://*.roblox.com/groups/*",
-        "https://stats.romonitor.silicon.digital/api/v1/extension/*"
+        "https://romonitorstats.com/api/v1/extension/*"
       ]
     }
   ],

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "RoMonitor Stats - Roblox Stats",
     "author": "Silicon Digital Group Ltd",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "View Roblox game analytics from RoMonitor Stats inside Roblox",
     "content_scripts": [
       {
@@ -16,7 +16,7 @@
           "*://*.roblox.com/games/*",
           "*://*.roblox.com/users/*",
           "*://*.roblox.com/groups/*",
-          "https://stats.romonitor.silicon.digital/api/v1/extension/*"
+          "https://romonitorstats.com/api/v1/extension/*"
         ]
       }
     ],
@@ -24,7 +24,7 @@
       "*://*.roblox.com/games/*",
       "*://*.roblox.com/users/*",
       "*://*.roblox.com/groups/*",
-      "https://stats.romonitor.silicon.digital/api/v1/extension/*",
+      "https://romonitorstats.com/api/v1/extension/*",
       "webRequest"
     ],
     "icons": {

--- a/stats.js
+++ b/stats.js
@@ -1,5 +1,5 @@
 let extensionConfiguration = {
-  apiEndpoint: 'https://stats.romonitor.silicon.digital/api/v1/extension/',
+  apiEndpoint: 'https://romonitorstats.com/api/v1/extension/',
   activePlaceID: null,
 };
 
@@ -112,7 +112,7 @@ function getTabs() {
     {
       title: 'RoMonitor Stats',
       id: 'go-to-stats',
-      href: `https://stats.romonitor.silicon.digital/game/${extensionConfiguration.activePlaceID}/?utm_source=roblox&utm_medium=extension&utm_campaign=extension_leadthrough`,
+      href: `https://romonitorstats.com/experience/${extensionConfiguration.activePlaceID}/?utm_source=roblox&utm_medium=extension&utm_campaign=extension_leadthrough`,
       target: '_blank',
     }
   ];
@@ -155,7 +155,7 @@ function buildTabs() {
 
       const containerHeader = document.createElement('div');
       containerHeader.classList.add('container-header');
-      containerHeader.innerHTML = `<h3>${tab.title}</h3><br><div class="text-secondary" style="margin-top: 1em;">Powered by <a href="https://stats.romonitor.silicon.digital/" class="text-link">RoMonitor Stats</a></div>`;
+      containerHeader.innerHTML = `<h3>${tab.title}</h3><br><div class="text-secondary" style="margin-top: 1em;">Powered by <a href="https://romonitorstats.com/" class="text-link">RoMonitor Stats</a></div>`;
       firstTabContent.appendChild(containerHeader);
     }
 


### PR DESCRIPTION
As part of the phased rollout plan for the romonitorstats.com domain - all requests will now go to romonitorstats.com instead of stats.romonitor.silicon.digital.