### PR TITLE
Add i18n

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,195 @@
+{
+    "extName": {
+        "message": "RoMonitor Stats - Roblox Stats",
+        "description": "Extension name at manifest.json"
+    },
+
+    "extDesc": {
+       "message": "View Roblox game analytics from RoMonitor Stats inside Roblox",
+       "description": "Extension description at manifest.json"
+    },
+
+    "tabStats": {
+        "message": "Stats",
+        "description": "New tab name"
+    },
+
+    "tabMilestones": {
+        "message": "Milestones",
+        "description": "New tab name"
+    },
+
+    "tabSocialGraph": {
+        "message": "Social Graph",
+        "description": "New tab name"
+    },
+
+    "tabNameChanges": {
+        "message": "Name Changes",
+        "description": "New tab name"
+    },
+
+    "tabRoMonitor": {
+        "message": "RoMonitor Stats",
+        "description": "New tab name"
+    },
+
+
+
+
+
+    "PoweredBy": {
+        "message": "Powered by",
+        "description": "Note that appears over every new tab"
+    },
+
+
+
+
+    "contactError": {
+        "message": "Unable to contact RoMonitor Stats",
+        "description": "Error displayed if API returns error"
+    },
+
+    "429Error": {
+        "message": "You're sending too many requests to RoMonitor Stats",
+        "description": "Error displayed if API returns 429"
+    },
+
+    "500Error": {
+        "message": "RoMonitor Stats hit an exception, our monitoring tool has logged this",
+        "description": "Error displayed if API returns 500"
+    },
+
+    "404Error": {
+        "message": "The RoMonitor Stats extension endpoint is not available",
+        "description": "Error displayed if API returns 404"
+    },
+
+    "502Error": {
+        "message": "RoMonitor Stats is currently undergoing maintainance",
+        "description": "Error displayed if API returns 502"
+    },
+
+    "422Error": {
+        "message": "Invalid request sent to RoMonitor Stats",
+        "description": "Error displayed if API returns 422"
+    },
+
+
+
+
+    "tableM_Milestone": {
+        "message": "Milestone",
+        "description": "Left title on name changes table"
+    },
+
+    "tableM_Achived": {
+        "message": "Achived",
+        "description": "Right title on name changes table"
+    },
+
+    "M_NotFound": {
+        "message": "This game has no tracked milestones",
+        "description": "Error displayed if the game doesn't have any milestones"
+    },
+
+    "Visits": {
+        "message": "Visitas",
+        "description": "Milestone text"
+    },
+
+    "Likes": {
+        "message": "Likes",
+        "description": "Milestone text"
+    },
+
+
+
+
+
+    "tableNC_Name": {
+        "message": "Name",
+        "description": "Left title on name changes table"
+    },
+
+    "tableNC_Changed": {
+        "message": "Changed",
+        "description": "Right title on name changes table"
+    },
+
+    "NC_NotFound": {
+        "message": "This game has no tracked name changes",
+        "description": "Error displayed if the game never changed its name"
+    },
+
+    "NC_LimitNote": {
+        "message": "Showing the Last 10 Name Changes",
+        "description": "Note that appears over the name changes table"
+    },
+    
+
+
+
+
+
+    "Highest_Players_Today": {
+        "message": "Highest Players Today",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Avg_Players_Today": {
+        "message": "Avg Players Today",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Highest_Players_This_Week": {
+        "message": "Highest Players This Week",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Avg_Players_This_Week": {
+        "message": "Avg Players This Week",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Rating": {
+        "message": "Rating",
+        "description": "Data displayed on the stats tab"
+    },
+
+
+
+
+
+
+    "Global_Reach": {
+        "message": "Global Reach",
+        "description": "Data displayed on the social tab"
+    },
+
+    "Discord_Online": {
+        "message": "Discord Online",
+        "description": "Data displayed on the social tab"
+    },
+
+    "Discord_Members": {
+        "message": "Discord Members",
+        "description": "Data displayed on the social tab"
+    },
+
+    "YouTube_Subscribers": {
+        "message": "YouTube Subscribers",
+        "description": "Data displayed on the social tab"
+    },
+
+    "YouTube_Views": {
+        "message": "YouTube Views",
+        "description": "Data displayed on the social tab"
+    },
+
+    "socials_NotFound": {
+        "message": "This game has no trackable social graph",
+        "description": "Error displayed if the game doesn't have any linked social media"
+    }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,196 @@
+{
+    "extName": {
+        "message": "RoMonitor Stats - Estadísticas de Roblox",
+        "description": "Extension name at manifest.json"
+    },
+
+    "extDesc": {
+       "message": "Observa analiticas de juegos de Roblox desde RoMonitor Stats dentro de Roblox",
+       "description": "Extension description at manifest.json"
+    },
+
+    "tabStats": {
+        "message": "Estadísticas",
+        "description": "New tab name"
+    },
+
+    "tabMilestones": {
+        "message": "Metas",
+        "description": "New tab name"
+    },
+
+    "tabSocialGraph": {
+        "message": "Grafo Social",
+        "description": "New tab name"
+    },
+
+    "tabNameChanges": {
+        "message": "Cambios de Nombre",
+        "description": "New tab name"
+    },
+
+    "tabRoMonitor": {
+        "message": "RoMonitor Stats",
+        "description": "New tab name"
+    },
+
+
+
+
+
+    "PoweredBy": {
+        "message": "Desarrollado por",
+        "description": "Note that appears over every new tab"
+    },
+
+
+
+
+    "contactError": {
+        "message": "Incapaz de conectarse a RoMonitor Stats",
+        "description": "Error displayed if API returns error"
+    },
+
+    "429Error": {
+        "message": "Estás enviando muchas solicitudes a RoMonitor Stats",
+        "description": "Error displayed if API returns 429"
+    },
+
+    "500Error": {
+        "message": "RoMonitor Stats tuvo un percance, nuestra herramienta de monitoreo lo ha registrado",
+        "description": "Error displayed if API returns 500"
+    },
+
+    "404Error": {
+        "message": "El endpoint de la extensión de RoMonitor Stats no está disponible",
+        "description": "Error displayed if API returns 404"
+    },
+
+    "502Error": {
+        "message": "RoMonitor Stats está actualmente en mantenimiento",
+        "description": "Error displayed if API returns 502"
+    },
+
+    "422Error": {
+        "message": "Solicitud inválida enviada a RoMonitor Stats",
+        "description": "Error displayed if API returns 422"
+    },
+
+
+
+
+    "tableM_Milestone": {
+        "message": "Meta",
+        "description": "Left title on name changes table"
+    },
+
+    "tableM_Achived": {
+        "message": "Conseguida",
+        "description": "Right title on name changes table"
+    },
+
+    "M_NotFound": {
+        "message": "Este juego no tiene metas monitoreadas",
+        "description": "Error displayed if the game doesn't have any milestones"
+    },
+
+    "Visits": {
+        "message": "Visitas",
+        "description": "Milestone text"
+    },
+
+    "Likes": {
+        "message": "Likes",
+        "description": "Milestone text"
+    },
+
+
+
+
+
+
+    "tableNC_Name": {
+        "message": "Nombre",
+        "description": "Left title on name changes table"
+    },
+
+    "tableNC_Changed": {
+        "message": "Cambiado",
+        "description": "Right title on name changes table"
+    },
+
+    "NC_NotFound": {
+        "message": "Este juego no tiene cambios de nombre monitoreados",
+        "description": "Error displayed if the game never changed its name"
+    },
+
+    "NC_LimitNote": {
+        "message": "Mostrando los Últimos 10 Cambios de Nombre",
+        "description": "Note that appears over the name changes table"
+    },
+    
+
+
+
+
+
+    "Highest_Players_Today": {
+        "message": "Máximo de Jugadores Hoy",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Avg_Players_Today": {
+        "message": "Jugadores Promedio Hoy",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Highest_Players_This_Week": {
+        "message": "Máximo de Jugadores Esta Semana",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Avg_Players_This_Week": {
+        "message": "Jugadores Promedio Esta Semana",
+        "description": "Data displayed on the stats tab"
+    },
+
+    "Rating": {
+        "message": "Calificación",
+        "description": "Data displayed on the stats tab"
+    },
+
+
+
+
+
+
+    "Global_Reach": {
+        "message": "Alcance Global",
+        "description": "Data displayed on the social tab"
+    },
+
+    "Discord_Online": {
+        "message": "En Línea en Discord",
+        "description": "Data displayed on the social tab"
+    },
+
+    "Discord_Members": {
+        "message": "Miembros en Discord",
+        "description": "Data displayed on the social tab"
+    },
+
+    "YouTube_Subscribers": {
+        "message": "Suscriptores de Youtube",
+        "description": "Data displayed on the social tab"
+    },
+
+    "YouTube_Views": {
+        "message": "Visualizaciones en Youtube",
+        "description": "Data displayed on the social tab"
+    },
+
+    "socials_NotFound": {
+        "message": "Este juego no tiene un grafo social monitoreado",
+        "description": "Error displayed if the game doesn't have any linked social media"
+    }
+}

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,9 +1,10 @@
 {
   "update_url": "https://clients2.google.com/service/update2/crx",
   "manifest_version": 3,
-  "name": "RoMonitor Stats - Roblox Stats",
+  "name": "__MSG_extName__",
   "version": "1.0.4",
-  "description": "View Roblox game analytics from RoMonitor Stats inside Roblox",
+  "description": "__MSG_extDesc__",
+  "default_locale": "en",
   "content_scripts": [
     {
       "js": [

--- a/stats.js
+++ b/stats.js
@@ -11,6 +11,7 @@ let gameData = null;
 let socialGraphData = null;
 let nameChangesGraphData = null;
 
+
 window.addEventListener('load', async function () {
   const check = await prefabChecks();
 
@@ -57,26 +58,26 @@ async function postData(data = {}) {
   })
     .then(response => {
       if (response.status === 429) {
-        this.createRobloxError("You're sending too many requests to RoMonitor Stats");
+        this.createRobloxError(chrome.i18n.getMessage('429Error'));
         return;
       } else if (response.status === 500) {
-        this.createRobloxError('RoMonitor Stats hit an exception, our monitoring tool has logged this');
+        this.createRobloxError(chrome.i18n.getMessage('500Error'));
         return;
       } else if (response.status === 404) {
-        this.createRobloxError('The RoMonitor Stats extension endpoint is not available');
+        this.createRobloxError(chrome.i18n.getMessage('404Error'));
         return;
       } else if (response.status === 502) {
-        this.createRobloxError('RoMonitor Stats is currently undergoing maintainance');
+        this.createRobloxError(chrome.i18n.getMessage('502Error'));
         return;
       } else if (response.status === 422) {
-        this.createRobloxError('Invalid request sent to RoMonitor Stats');
+        this.createRobloxError(chrome.i18n.getMessage('422Error'));
         return;
       }
 
       return response.json();
     })
     .catch((error) => {
-      this.createRobloxError('Unable to contact RoMonitor Stats');
+      this.createRobloxError(chrome.i18n.getMessage('contactError'));
       Promise.reject(error);
     });
 }
@@ -94,29 +95,30 @@ function createRobloxError(message, icon = 'icon-warning', code = null) {
 function getTabs() {
   return [
     {
-      title: 'Stats',
+      title: chrome.i18n.getMessage('tabStats'),
       id: 'stats',
     },
     {
-      title: 'Milestones',
+      title: chrome.i18n.getMessage('tabMilestones'),
       id: 'milestones',
     },
     {
-      title: 'Social Graph',
+      title: chrome.i18n.getMessage('tabSocialGraph'),
       id: 'social-graph',
     },
     {
-      title: 'Name Changes',
+      title: chrome.i18n.getMessage('tabNameChanges'),
       id: 'name-changes',
     },
     {
-      title: 'RoMonitor Stats',
+      title: chrome.i18n.getMessage('tabRoMonitor'),
       id: 'go-to-stats',
       href: `https://romonitorstats.com/experience/${extensionConfiguration.activePlaceID}/?utm_source=roblox&utm_medium=extension&utm_campaign=extension_leadthrough`,
       target: '_blank',
     }
   ];
 }
+
 
 function buildTabs() {
   lastAddedTab = null;
@@ -155,14 +157,14 @@ function buildTabs() {
 
       const containerHeader = document.createElement('div');
       containerHeader.classList.add('container-header');
-      containerHeader.innerHTML = `<h3>${tab.title}</h3><br><div class="text-secondary" style="margin-top: 1em;">Powered by <a href="https://romonitorstats.com/" class="text-link">RoMonitor Stats</a></div>`;
+      containerHeader.innerHTML = `<h3>${tab.title}</h3><br><div class="text-secondary" style="margin-top: 1em;">${chrome.i18n.getMessage('PoweredBy')} <a href="https://romonitorstats.com/" class="text-link">RoMonitor Stats</a></div>`;
       firstTabContent.appendChild(containerHeader);
     }
 
     /** The following are lightweight queries to our servers, so we build these to make the tabs load faster, others are dynamically injected. */
-    if (tab.title === 'Milestones') {
+    if (tab.title === chrome.i18n.getMessage('tabMilestones')) {
       buildMilestonesTab();
-    } else if (tab.title === 'Stats') {
+    } else if (tab.title === chrome.i18n.getMessage('tabStats')) {
       buildStatsTab();
     }
 
@@ -170,6 +172,7 @@ function buildTabs() {
       addTabListener(newTab, firstTabContent)
     }
   });
+
 
   /** Adds event listeners to the default Roblox tabs */
   const baseRobloxTabs = ['about', 'store', 'game-instances'];
@@ -251,6 +254,17 @@ function removeAllTabActiveStates() {
   }
 }
 
+function findTranslation(str) {
+  var replaced = str.split(' ').join('_');
+  var translation = chrome.i18n.getMessage(replaced);
+
+  if (translation != '') {
+    return translation
+  } else {
+    return str
+  }
+}
+
 function buildStatsTab() {
   const statsContainer = document.getElementsByClassName('tab-pane stats');
   const flexboxContainer = document.createElement('div');
@@ -260,7 +274,7 @@ function buildStatsTab() {
   const upVotes = Number(document.getElementsByClassName('count-left')[0].firstElementChild.title)
   const downVotes = Number(document.getElementsByClassName('count-right')[0].firstElementChild.title)
   gameData.stats.items.push({
-    title: 'Rating',
+    title: chrome.i18n.getMessage('Rating'),
     copy: `${(upVotes / (upVotes + downVotes) * 100).toFixed(2)}%`,
   });
 
@@ -272,7 +286,7 @@ function buildStatsTab() {
 ">${item.copy}</h2>
     <p style="
     text-align: center;
-">${item.title}</p>`
+">${findTranslation(item.title)}</p>`
     flexboxContainer.appendChild(gridEntry);
   });
 
@@ -284,13 +298,13 @@ function buildMilestonesTab() {
   const milestonesTable = document.createElement('table');
   milestonesTable.classList.add('table');
   milestonesTable.classList.add('table-striped');
-  milestonesTable.innerHTML = '<thead><tr><th class="text-label">Milestone</th><th class="text-label">Achived</th></tr></thead><tbody id="milestones-table"></tbody>';
+  milestonesTable.innerHTML = `<thead><tr><th class="text-label">${chrome.i18n.getMessage('tableM_Milestone')}</th><th class="text-label">${chrome.i18n.getMessage('tableM_Achived')}</th></tr></thead><tbody id="milestones-table"></tbody>`;
 
   if (!Object.keys(gameData.milestones).length) {
     const messageBanner = document.createElement('div');
 
     messageBanner.classList.add('message-banner');
-    messageBanner.innerHTML = `<span class="icon-warning"></span> This game has no tracked milestones`;
+    messageBanner.innerHTML = `<span class="icon-warning"></span> ${chrome.i18n.getMessage('M_NotFound')}`;
     messageBanner.style = 'margin-bottom: 1em; margin-top: 1em;';
     milestonesContainer[0].appendChild(messageBanner);
 
@@ -301,7 +315,7 @@ function buildMilestonesTab() {
   Object.keys(gameData.milestones).reverse().forEach((milestoneIndex) => {
     const milestone = gameData.milestones[milestoneIndex];
     const milestoneEntry = document.createElement('tr');
-    milestoneEntry.innerHTML = `<td>${milestone.value} ${milestone.type}</td><td>${milestone.achieved}</td>`;
+    milestoneEntry.innerHTML = `<td>${milestone.value} ${findTranslation(milestone.type)}</td><td>${milestone.achieved}</td>`;
 
     document.getElementById('milestones-table').appendChild(milestoneEntry);
   });
@@ -313,13 +327,13 @@ function buildNameChangesTab() {
   const nameChangesTable = document.createElement('table');
   nameChangesTable.classList.add('table');
   nameChangesTable.classList.add('table-striped');
-  nameChangesTable.innerHTML = '<thead><tr><th class="text-label">Name</th><th class="text-label">Changed</th></tr></thead><tbody id="name-changes-table"></tbody>';
+  nameChangesTable.innerHTML = `<thead><tr><th class="text-label">${chrome.i18n.getMessage('tableNC_Name')}</th><th class="text-label">${chrome.i18n.getMessage('tableNC_Changed')}</th></tr></thead><tbody id="name-changes-table"></tbody>`;
 
   if (!Object.keys(nameChangesGraphData).length) {
     const messageBanner = document.createElement('div');
 
     messageBanner.classList.add('message-banner');
-    messageBanner.innerHTML = `<span class="icon-warning"></span> This game has no tracked name changes`;
+    messageBanner.innerHTML = `<span class="icon-warning"></span> ${chrome.i18n.getMessage('NC_NotFound')}`;
     messageBanner.style = 'margin-bottom: 1em; margin-top: 1em;';
     nameChangesContainer[0].appendChild(messageBanner);
 
@@ -327,7 +341,7 @@ function buildNameChangesTab() {
   }
   const limitWarning = document.createElement('div');
   limitWarning.classList.add('text-label');
-  limitWarning.innerHTML = 'Showing the Last 10 Name Changes';
+  limitWarning.innerHTML = chrome.i18n.getMessage('NC_LimitNote');
 
   nameChangesContainer[0].appendChild(limitWarning);
   nameChangesContainer[0].appendChild(nameChangesTable);
@@ -349,7 +363,7 @@ function buildSocialGraphTab() {
     const socialGraphMessageBanner = document.createElement('div');
 
     socialGraphMessageBanner.classList.add('message-banner');
-    socialGraphMessageBanner.innerHTML = `<span class="icon-warning"></span> This game has no trackable social graph`;
+    socialGraphMessageBanner.innerHTML = `<span class="icon-warning"></span> ${chrome.i18n.getMessage('socials_NotFound')}`;
     socialGraphMessageBanner.style = 'margin-bottom: 1em; margin-top: 1em;';
     socialGraphContainer[0].appendChild(socialGraphMessageBanner);
   } else {
@@ -364,7 +378,7 @@ function buildSocialGraphTab() {
   ">${item.copy}</h2>
       <p style="
       text-align: center;
-  ">${item.title}</p>`
+  ">${findTranslation(item.title)}</p>`
       flexboxContainer.appendChild(gridEntry);
     });
 


### PR DESCRIPTION
Using the [built-in feature](https://developer.chrome.com/docs/extensions/reference/i18n/) of google chrome extensions I added i18n support to the RoMonitor Stats extension, as well as Spanish Localizations. Initially, I wanted to set the language by the one that can be changed at the bottom of the Roblox website, but I thought it would be easier to use the one already provided by chrome.

### Contributing
Also, if someone wants to contribute localizating the extension is pretty easy, just clone the `en` folder inside `_locales` and change the name to the locale code you want to translate it to!, then on the `message.json` replace the `message` fields with the localized strings (there's also a field named description to know context about the string).

### Suggestion
I think a great feature for the RoMonitor main website would be i18n support (that’s one of the reasons I made this), the localizations could be contributed by the community using something like [Crowdin](https://crowdin.com). By doing this the website could expand to a bigger audience. _Finally, I would like to discuss some other features or changes for RoMonitor but a PR is not the right place to do it :D_